### PR TITLE
scipy.interpolate.spline is deprecated and a.dtype.fields.keys() is unpredictable

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -22,7 +22,7 @@ from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
 from sklearn.preprocessing import LabelEncoder
 
-from scipy.interpolate import spline
+from scipy.interpolate import interp1d
 from scipy.io import loadmat
 
 def readucr(filename):
@@ -141,7 +141,8 @@ def transform_to_same_length(x,n_var,max_length):
         for j in range(n_var):
             ts = mts[j]
             # linear interpolation
-            new_ts = spline(idx,ts,idx_new)
+            f = interp1d(idx, ts, kind='cubic')
+            new_ts = f(idx_new)
             ucr_x[i,:,j] = new_ts
 
     return ucr_x

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -163,7 +163,7 @@ def transform_mts_to_ucr_format():
         a = a['mts']
         a = a[0,0]
 
-        dt = a.dtype.fields.keys()
+        dt = a.dtype.names
         dt = list(dt)
 
         for i in range(len(dt)):


### PR DESCRIPTION
1.
As of SciPy 0.19.0, `scipy.interpolate.spline` is deprecated. I have replaced the use of `scipy.interpolate.spline` with `scipy.interpolate.interp1d`.

**previous code**
`new_ts = spline(idx,ts,idx_new)`

**new code**
```
f = interp1d(idx, ts, kind='cubic')
new_ts = f(idx_new)
```

2.
`dt = a.dtype.fields.keys()` returns keys in an unpredictable order. I'm wondering if this could be due to my use of a version of Python < 3.7. I have replaced the line with `dt = a.dtype.names`, which has the same function but returns the names in order.